### PR TITLE
fix GitHub project name in setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='django-chartjs-engine',
       version='0.0.3',
       description='Django app to build chartjs javascript charts',
-      url='https://github.com/deltaskelta/django-chartjs_engine',
+      url='https://github.com/deltaskelta/django-chartjs-engine',
       author='Jeff Willette',
       author_email='jrwillette88@gmail.com',
       keywords = ['django', 'chartjs', 'javascript', 'charts'],


### PR DESCRIPTION
django-chartjs_engine -> django-chartjs-engine

Tiniest commit ever, but it did break the link to the project from PyPI so I thought you'd want to know -- but feel free to ignore this PR and just roll the change into whenever you next edit setup.py if you prefer... 😄 

Thanks for sharing your code!